### PR TITLE
HOPSFS-127: Bump Hops Hadoop version to 3.2.0.12 SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>io.hops</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>3.2.0.6-EE-SNAPSHOT</version>
+            <version>3.2.0.12-EE-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
HOPSFS-127: Bump Hops Hadoop version to 3.2.0.12 SNAPSHOT