### PR TITLE
HOPSFS-139 Bump Hops Hadoop Version to 3.2.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>io.hops</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>3.2.0.12-EE-SNAPSHOT</version>
+            <version>3.2.0.12-EE-RC0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
HOPSFS-139 Bump Hops Hadoop Version to 3.2.0.12