### PR TITLE
HOPSFS-256 Bump Hops Hadoop Version to 3.2.0.16-RC0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>io.hops</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>3.2.0.15-EE-RC0</version>
+            <version>3.2.0.16-EE-RC0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
HOPSFS-256 Bump Hops Hadoop Version to 3.2.0.16-RC0